### PR TITLE
Deprecate UI and Virtual component tables in Equipment

### DIFF
--- a/.annotations/photon-v2.lua
+++ b/.annotations/photon-v2.lua
@@ -201,10 +201,6 @@ PhotonMaterial = PhotonMaterial
 ---@field BodyGroups? PhotonEquipmentBodyGroupEntry[]
 -- Sub materials.
 ---@field SubMaterials? PhotonEquipmentSubMaterialEntry[]
--- For Photon components that don't create standalone entities.
----@field VirtualComponents? PhotonEquipmentVirtualComponentEntry[]
--- For UI components (used for the HUD indicator).
----@field UIComponents? PhotonEquipmentUIComponentEntry[]
 -- User HUD sounds (i.e. beeps and clicks).
 ---@field InteractionSounds? PhotonEquipmentInteractionSoundEntry[]
 
@@ -253,10 +249,6 @@ PhotonMaterial = PhotonMaterial
 ---@field Inherit? string Name of an equipment entry to inherit from.
 
 ---@class PhotonEquipmentComponentEntry : PhotonEquipmentEntityProperties, PhotonEquipmentLibraryComponentProperties
-
----@class PhotonEquipmentVirtualComponentEntry : PhotonEquipmentEntryProperties, PhotonEquipmentLibraryComponentProperties
-
----@class PhotonEquipmentUIComponentEntry : PhotonEquipmentEntryProperties, PhotonEquipmentLibraryComponentProperties
 
 ---@class PhotonEquipmentPropEntry : PhotonEquipmentEntityProperties
 ---@field Model? string Model path. (e.g. `models/my/props/model.mdl`)

--- a/lua/entities/photon_controller/cl_init.lua
+++ b/lua/entities/photon_controller/cl_init.lua
@@ -96,12 +96,6 @@ function ENT:DoNextFrame()
 	for i=1,#componentArray do
 		if ( componentArray[i].FrameTick) then componentArray[i]:FrameTick() end -- ***rebuild component array on equipment change *** 
 	end
-	for i=1, #self.VirtualComponentArray do
-		self.VirtualComponentArray[i]:FrameTick()
-	end
-	for i=1, #self.UIComponentArray do
-		self.UIComponentArray[i]:FrameTick()
-	end
 end
 
 function ENT:DoPulse()

--- a/lua/photon-v2/cl_hud.lua
+++ b/lua/photon-v2/cl_hud.lua
@@ -320,6 +320,24 @@ function HUD.SceneLightingIndicator( x, y, icon, frontOn, floodOn, rightOn, back
 	surface.DrawTexturedRect( x + 20, y + 21, 12, 12 )
 end
 
+-- Utility function that draws a fixed box. I made it so 
+-- I could capture screenshots/recordings with the same
+-- perspective and dimensions for the Wiki.
+function HUD.DrawTargetBox( w, h )
+	local centerX = ScrW() / 2
+	local centerY = ScrH() / 2
+
+	-- surface.SetDrawColor( 255, 255, 255, 255 )
+	draw.RoundedBox( 0, centerX - (w/2), centerY - (h/2), w, 1, Color( 255, 255, 255 ) )
+	draw.RoundedBox( 0, centerX - (w/2), centerY - (h/2), 1, h, Color( 255, 255, 255 ) )
+	draw.RoundedBox( 0, centerX - (w/2), centerY + (h/2), w, 1, Color( 255, 255, 255 ) )
+	draw.RoundedBox( 0, centerX + (w/2), centerY - (h/2), 1, h, Color( 255, 255, 255 ) )
+end
+
+-- hook.Add( "PostDrawHUD", "Photon2.TargetBox", function() 
+-- 	HUD.DrawTargetBox( 400, 128 )
+-- end)
+
 function HUD.KeyBindHint( x, y, keys )
 	local key
 	local keyPadding = 7
@@ -479,15 +497,19 @@ local hintDuration = 7
 
 local drawHeight = 0
 local hudStartTime = 0
+local indicatorComponent = nil
 
 local hintInfoVisible = false
 
 hook.Add( "HUDPaint", "Photon2:RenderHudRT", function()
 	-- if true then return end
 	local target = Photon2.ClientInput.TargetController
-	local indicatorComponent
 
-	if ( not target ) then hudStartTime = 0 return end
+	if ( not target ) then 
+		hudStartTime = 0
+		indicatorComponent = nil
+		return
+	end
 
 	if ( not Photon2.ClientInput.Active ) then return end
 
@@ -501,10 +523,12 @@ hook.Add( "HUDPaint", "Photon2:RenderHudRT", function()
 			hintInfoVisible = true
 		end
 
-		for k, v in pairs( target.UIComponents ) do
-			if ( v.PrintName == "Photon 2 HUD" ) then
-				indicatorComponent = v
-				break
+		if ( not indicatorComponent ) then
+			for k, v in pairs( target.ComponentArray ) do
+				if ( v.PrintName == "Photon 2 HUD" ) then
+					indicatorComponent = v
+					break
+				end
 			end
 		end
 

--- a/lua/photon-v2/cl_render_light_bone.lua
+++ b/lua/photon-v2/cl_render_light_bone.lua
@@ -45,4 +45,3 @@ function Photon2.RenderPoseElement.Update()
 	pose.Active = nextTable
 end
 hook.Add( "PreRender", "Photon2.PoseElement:Update", pose.Update )
--- hook.Remove( "", "Photon2.PoseElement:Update" )

--- a/lua/photon-v2/library/vehicles/default_sgm_forexp13.lua
+++ b/lua/photon-v2/library/vehicles/default_sgm_forexp13.lua
@@ -17,7 +17,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Default",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_sgmfpiu13",
 					}

--- a/lua/photon-v2/library/vehicles/photon_sgm_cvpi96_ftc_co_pd.lua
+++ b/lua/photon-v2/library/vehicles/photon_sgm_cvpi96_ftc_co_pd.lua
@@ -43,7 +43,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "HUD",
-				UIComponents = {
+				Components = {
 					{
 						Component = "photon_hud_default"
 					}
@@ -73,7 +73,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Default",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_sgmcvpi96",
 						Position = Vector( 0, 0, 0 ),

--- a/lua/photon-v2/library/vehicles/photon_sgm_durang21_co_csp.lua
+++ b/lua/photon-v2/library/vehicles/photon_sgm_durang21_co_csp.lua
@@ -20,7 +20,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "HUD",
-				UIComponents = {
+				Components = {
 					{
 						Component = "photon_hud_default"
 					}
@@ -62,7 +62,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Standard Lighting",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_sgmdodur21",
 						Inputs = {

--- a/lua/photon-v2/library/vehicles/photon_sgm_fpiu13_sea_pd.lua
+++ b/lua/photon-v2/library/vehicles/photon_sgm_fpiu13_sea_pd.lua
@@ -167,7 +167,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Enabled",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_sgmfpiu13",
 						Inputs = {
@@ -465,7 +465,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "HUD",
-				UIComponents = {
+				Components = {
 					{
 						Component = "photon_hud_default"
 					}

--- a/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_bou_co_pd.lua
+++ b/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_bou_co_pd.lua
@@ -49,7 +49,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "HUD",
-				UIComponents = {
+				Components = {
 					{
 						Component = "photon_hud_default"
 					}
@@ -612,7 +612,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Standard Lighting",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_sgmfpiu20",
 						Flags = {

--- a/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_bou_co_so.lua
+++ b/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_bou_co_so.lua
@@ -68,7 +68,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Vehicle Lighting",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_sgmfpiu20"
 					}

--- a/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_mpdc.lua
+++ b/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_mpdc.lua
@@ -120,7 +120,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Standard Lighting",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_sgmfpiu20",
 						States = { "B", "B" },

--- a/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_unmarked.lua
+++ b/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_unmarked.lua
@@ -173,7 +173,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Standard Lighting",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_sgmfpiu20"
 					}

--- a/lua/photon-v2/library/vehicles/photon_sm_fpiu16_lvmpd.lua
+++ b/lua/photon-v2/library/vehicles/photon_sm_fpiu16_lvmpd.lua
@@ -54,7 +54,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "HUD",
-				UIComponents = {
+				Components = {
 					{
 						Component = "photon_hud_default"
 					}
@@ -67,7 +67,7 @@ VEHICLE.Equipment = {
 		Options = {
 			{
 				Option = "Default",
-				VirtualComponents = {
+				Components = {
 					{
 						Component = "photon_standard_smfpiu16",
 						Segments = {

--- a/lua/photon-v2/meta/lighting_component.lua
+++ b/lua/photon-v2/meta/lighting_component.lua
@@ -120,6 +120,11 @@ function Component.New( name, data )
 		States = data.States
 	}
 
+	-- Assume components without a model defined are virtual
+	if ( data.IsVirtual == nil ) then
+		if ( component.Model == nil ) then component.IsVirtual = true end
+	end
+
 	for key, value in pairs( data ) do
 		if ( component[key] == nil ) then
 			component[key] = value

--- a/lua/photon-v2/meta/vehicle_equipment.lua
+++ b/lua/photon-v2/meta/vehicle_equipment.lua
@@ -23,8 +23,6 @@ function Equipment.GetTemplate()
 		Props = {},
 		BodyGroups = {},
 		SubMaterials = {},
-		VirtualComponents = {},
-		UIComponents = {},
 		InteractionSounds = {}
 	}
 end
@@ -33,6 +31,18 @@ end
 function Equipment.ApplyTemplate( tbl )
 	for k, v in pairs( Equipment.GetTemplate() ) do
 		tbl[k] = rawget( tbl, k ) or v
+	end
+end
+
+function Equipment.PreMergeEquipment( selection, mergeMap )
+	for mergeFrom, mergeTo in pairs( mergeMap ) do
+		if ( istable( selection[mergeFrom] ) ) then
+			selection[mergeTo] = selection[mergeTo] or {}
+			for i=1, #selection[mergeFrom] do
+				selection[mergeTo][#selection[mergeTo]+1] = selection[mergeFrom][i]
+			end
+		end
+		selection[mergeFrom] = {}
 	end
 end
 

--- a/lua/photon-v2/sh_util.lua
+++ b/lua/photon-v2/sh_util.lua
@@ -21,7 +21,7 @@ function Photon2.Util.ReferentialCopy( target, meta )
 end
 
 -- A more expensive version of table.Copy that doesn't reuse 
--- metatables, can cause issues with Photon's inheritance.
+-- metatables, which can cause issues with Photon's inheritance.
 function Photon2.Util.UniqueCopy( tbl )
 	local copy = {}
 	for k, v in pairs( tbl ) do
@@ -33,20 +33,6 @@ function Photon2.Util.UniqueCopy( tbl )
 	end
 	return copy
 end
--- local function clearMarkers( tbl )
--- 	local keys = {}
--- 	for key, value in pairs( tbl ) do
--- 		if isstring( key ) and ( string.StartsWith( key, "!" ) ) then
--- 			keys[#keys+1] = key
--- 		elseif ( istable( value ) ) then
--- 			clearMarkers( tbl )
--- 		end
--- 	end
--- 	for i=1, #keys do
--- 		tbl[string.sub( key, 2)] = value
--- 		tbl[key] = nil
--- 	end
--- end
 
 function Photon2.Util.SimpleInherit( target, base )
 	base = table.Copy( base )
@@ -80,16 +66,6 @@ function Photon2.Util.Inherit( target, base )
 	for key, value in pairs( base ) do
 		local raw = rawget( target, key )
 		
-		-- if ( raw == nil and isstring( key ) ) then
-		-- 	local magicKey = "!" .. key
-		-- 	if ( rawget( target, magicKey ) ) then
-		-- 		raw = rawget( target, magicKey )
-		-- 		target[key] = raw
-		-- 		target[key]["__no_inherit"] = true
-		-- 		target[magicKey] = nil
-		-- 	end
-		-- end
-		
 		if ( raw == nil ) then
 			target[key] = value
 		elseif ( raw == PHOTON2_UNSET ) then
@@ -102,66 +78,11 @@ function Photon2.Util.Inherit( target, base )
 			end
 		end
 	end
-	
-	-- for key, value in pairs ( target ) do
-	-- 	if ( isstring( key ) and string.StartsWith( key, "!" ) ) then
-	-- 		-- print("found extra non-inherited key: " .. tostring( key))
-	-- 		-- print("should be: " .. string.sub(key, 2))
-	-- 		target[string.sub(key, 2)] = value
-	-- 	end
-	-- end
-
-	-- clearMarkers( target )
 
 	metaTable.__inherits = base
 	metaTable.__inheritedAt = CurTime()
 	return target
 end
-
--- function Photon2.Util.CacheModelMesh( model, meshes )
--- 	local materialLookup = {}
--- 	Util.ModelMeshMap[model] = {}
--- 	for k, v in pairs( meshes or util.GetModelMeshes( model )) do
--- 		local material = v.material
--- 		-- local material = string.GetFileFromFilename( v.material )
--- 		if ( not materialLookup[material] ) then
--- 			materialLookup[material] = 0
--- 		end
--- 		materialLookup[material] = materialLookup[material] + 1
--- 		Photon2.Util.ModelMeshMap[model][material .. "[".. materialLookup[material] .. "]"] = k
--- 	end
--- 	print("MATERIAL LOOKUP RESULT")
--- 	PrintTable( materialLookup )
--- end
-
--- function Photon2.Util.GetModelMesh( model, mesh, index )
--- 	index = index or 1
-	
--- 	local meshes
-	
--- 	if ( isstring( mesh ) ) then
--- 		local prev = mesh
--- 		if ( Util.ModelMeshMap[model] == nil ) then
--- 			meshes = util.GetModelMeshes( model )
--- 			Util.CacheModelMesh( model, meshes )
--- 		end
--- 		mesh = Util.ModelMeshMap[model][mesh .. "[" .. index .. "]"]
--- 		if ( not mesh ) then
--- 			error("No mesh with material '" .. tostring(prev) .."' was found on model '" .. tostring(mdl) .. "'")
--- 		end
--- 	end
-
--- 	if ( isnumber( mesh ) ) then
--- 		Util.ModelMeshes[model] = Util.ModelMeshes[model] or {}
--- 		if ( not Util.ModelMeshes[model][mesh] ) then
--- 			meshes = meshes or util.GetModelMeshes( model )
--- 			Util.ModelMeshes[model][mesh] = Mesh()
--- 			Util.ModelMeshes[model][mesh]:BuildFromTriangles( meshes[mesh].triangles )
--- 		end
--- 	end
-
--- 	return Util.ModelMeshes[model][mesh]
--- end
 
 function Photon2.Util.FindBodyGroupOptionByName( ent, bodyGroupIndex, name )
 	if ( string.len(name) > 0 ) then name = name .. ".smd" end
@@ -193,26 +114,34 @@ function Photon2.Util.PrintTableProperties( tbl )
 	print("\nEND   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n")
 end
 
--- Runs a function if it is indeed a function.
-function Photon2.Run( func )
-	if ( isfunction( func ) ) then func() end
-end
-
+-- Returns an input key name or `"(INVALID)"` instead of nil
+-- so you don't have to use fucking `tostring(result)` every time.
 function Photon2.Util.GetKeyName( key )
 	local result = input.GetKeyName( key )
 	result = result or "(INVALID)"
 	return result
 end
 
+-- Finds sub-materials on an entity that match those of its parent
+-- and generates a map of their indexes lik `{ [ParentIndex] = ChildIndex }`.
+---@param ent Entity
 function Photon2.Util.BuildParentSubMaterialMap( ent )
-	local childMaterials = ent:GetMaterials()
+	return Photon2.Util.BuildSubMaterialMap( ent:GetParent(), ent )
+end
+
+-- Finds sub-materials on `toEnt` that match those of `fromEnt`
+-- and generates a map of their indexes lik `{ [fromIndex] = toIndex }`.
+---@param fromEnt Entity (Usually the parent entity)
+---@param toEnt Entity (Usually the child entity)
+function Photon2.Util.BuildSubMaterialMap( fromEnt, toEnt )
+	local toMaterials = toEnt:GetMaterials()
 	local map = {}
-	for key, name in pairs( childMaterials ) do
-		childMaterials[name] = key
+	for key, name in pairs( toMaterials ) do
+		toMaterials[name] = key
 	end
-	for key, name in pairs( ent:GetParent():GetMaterials() ) do
-		if ( childMaterials[name] ) then 
-			map[key-1] = childMaterials[name]-1 
+	for key, name in pairs( fromEnt:GetMaterials() ) do
+		if ( toMaterials[name] ) then 
+			map[key-1] = toMaterials[name]-1
 		end
 	end
 	return map


### PR DESCRIPTION
- Components without a `.Model` are assumed to be virtual, making `.IsVirtual = true` unnecessary

- Entries made in .UIComponents and .VirtualComponents should now be placed in .Components. Virtual/UI components are now correctly dealt with automatically

- .VirtualComponents and .UIComponents will continue to work, but internally just move their contents into .Components