### PR TITLE
Add VEHICLE.Livery shortcut support

### DIFF
--- a/.annotations/photon-v2.lua
+++ b/.annotations/photon-v2.lua
@@ -208,6 +208,7 @@ PhotonMaterial = PhotonMaterial
 
 ---@class PhotonVehicleSelectionCategory
 ---@field Category string Category name.
+---@field Visible? boolean If category should be visible in menu.
 ---@field Options PhotonVehicleSelectionOption[]
 
 ---@class PhotonVehicleSelectionOption : PhotonEquipmentTable

--- a/lua/entities/photon_controller/shared.lua
+++ b/lua/entities/photon_controller/shared.lua
@@ -587,6 +587,7 @@ function ENT:SetupBodyGroup( id )
 end
 
 function ENT:SetParentSubMaterial( index, material )
+	if ( index == "SKIN" ) then index = Photon2.Util.FindSkinSubMaterial( self:GetParent() ) end
 	self:GetParent():SetSubMaterial( index, material )
 	if ( self.SyncAttachedParentSubMaterials ) then
 		for i, child in pairs( self:GetParent():GetChildren() ) do
@@ -702,7 +703,7 @@ function ENT:RemoveSubMaterialByIndex( index )
 	local parent = self:GetParent()
 	if ( not IsValid( parent ) ) then return end
 	if ( self.SubMaterials[index] ) then
-		parent:SetSubMaterial( self.SubMaterials[index].Id, nil )
+		self:SetParentSubMaterial( self.SubMaterials[index].Id, nil )
 	end
 	self.SubMaterials[index] = nil
 end

--- a/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_mpdc.lua
+++ b/lua/photon-v2/library/vehicles/photon_sgm_fpiu20_mpdc.lua
@@ -28,31 +28,34 @@ local livery = PhotonMaterial.New({
 	}
 })
 
-VEHICLE.SubMaterials = {
-	[3] = "photon/common/blank"
-}
+-- VEHICLE.SubMaterials = {
+-- 	[3] = "photon/common/blank"
+-- 	-- [3] = "photon/common/blank"
+-- }
 
 VEHICLE.Siren = { "sos_nergy400" }
 
+VEHICLE.Livery = livery.MaterialName
+
 -- Category -> Option (-> Variant)
 VEHICLE.Equipment = {
-	{
-		Category = "Liveries",
-		Options = {
-			{
-				Option = "MPDC",
-				SubMaterials = {
-					{ Id = 20, Material = livery.MaterialName },
-				}
-			},
-			{
-				Option = "None",
-				SubMaterials = {
-					{ Id = 20, Material = nil }
-				}
-			}
-		}
-	},
+	-- {
+	-- 	Category = "Liveries",
+	-- 	Options = {
+	-- 		{
+	-- 			Option = "MPDC",
+	-- 			SubMaterials = {
+	-- 				{ Id = "SKIN", Material = livery.MaterialName },
+	-- 			}
+	-- 		},
+	-- 		{
+	-- 			Option = "None",
+	-- 			SubMaterials = {
+	-- 				{ Id = 20, Material = nil }
+	-- 			}
+	-- 		}
+	-- 	}
+	-- },
 	{
 		Category = "Controller Sound",
 		Options = {

--- a/lua/photon-v2/sh_util.lua
+++ b/lua/photon-v2/sh_util.lua
@@ -156,4 +156,25 @@ function Photon2.Util.ReloadAllControllers()
 	end
 end
 
+local skinSearch = { "skin0", "skin", "skin1" }
+-- Micro-optimize the search smiley face
+for i=1, #skinSearch do
+	skinSearch[skinSearch[i]] = true
+end
+
+local skinCache = {}
+function Photon2.Util.FindSkinSubMaterial( ent )
+	if ( not IsValid( ent ) ) then return 0 end
+	if ( skinCache[ent:GetModel()] ) then return skinCache[ent:GetModel()] end
+
+	for i, mat in ipairs( ent:GetMaterials() ) do
+		if ( skinSearch[string.sub( mat, 1 - string.find( string.reverse( mat ), "/", 0, false ) )] ) then
+			skinCache[ent:GetModel()] = i - 1
+			return i - 1
+		end
+	end
+
+	return -1
+end
+
 -- PrintTable(Util.ModelMeshes)


### PR DESCRIPTION
- You can now specify `VEHICLE.Livery = "path/to/material"` to set a vehicle's livery as an alternative to needing to use Equipment

- When configuring SubMaterials in the Equipment table you can optionally use `"SKIN"` instead of a sub-material index (`{ Id = "SKIN", Material = "material" }`), which will cause Photon to automatically find the skin sub-material index (should work on most standard vehicles)

- (A dedicated, multiple liveries system is still be worked on)

- I meant to make this commit in the main branch