### PR TITLE
Implement workaround for #15

### DIFF
--- a/lua/entities/photon_controller/cl_init.lua
+++ b/lua/entities/photon_controller/cl_init.lua
@@ -41,12 +41,16 @@ end
 -- when loading in next to an already active Photon vehicle, especially 
 -- if the vehicle relies on Photon's dynamic materials.
 function ENT:DoInitializationStandby()
-	if ( not Photon2.Materials.Ready ) then
+	if ( not Photon2.Materials.Ready or ( not self:GetProfileName() ) ) then
 		timer.Simple( 1, function() 
 			if ( not IsValid( self ) ) then return end
 			pcall( self.DoInitializationStandby, self )
 		end)
 		return
+	end
+
+	if ( self:GetProfileName() ) then
+		self:SetupProfile( self:GetProfileName() )
 	end
 
 	local queue = Photon2.cl_Network.ControllerQueue[self]

--- a/lua/entities/photon_controller/init.lua
+++ b/lua/entities/photon_controller/init.lua
@@ -30,11 +30,12 @@ function ENT:Initialize()
 	end)
 end
 
-function ENT:SetProfileName( name )
-	-- Photon2.Debug.Print( "Setting controller profile name to " .. name )
-	self:SetNW2String( "Photon2:ProfileName", name )
-	self:SetupProfile( name )
-end
+-- function ENT:SetProfileName( name )
+-- 	-- Photon2.Debug.Print( "Setting controller profile name to " .. name )
+-- 	-- self:SetNW2String( "Photon2:ProfileName", name )
+-- 	self:SetDTString( 0, name )
+-- 	self:SetupProfile( name )
+-- end
 
 
 function ENT:SetSelectionOption( categoryIndex, optionIndex )
@@ -49,7 +50,7 @@ end
 
 -- 
 function ENT:SyncSelections()
-	self:SetNW2String( "Photon2:Selections", table.concat(self.CurrentSelections," "))
+	self:GetParent():SetNW2String( "Photon2:Selections", table.concat(self.CurrentSelections," "))
 end
 
 function ENT:PlayerEnteredLinkedVehicle( ply, vehicle, role )

--- a/lua/entities/photon_controller/shared.lua
+++ b/lua/entities/photon_controller/shared.lua
@@ -182,6 +182,9 @@ function ENT:SetupDataTables()
 
 	self:NetworkVar( "Int",  0, "VehicleSpeed" )
 
+	self:NetworkVar( "String", 0, "ProfileName" )
+
+	self:NetworkVarNotify( "ProfileName", self.OnProfileNameChange )
 	self:NetworkVarNotify( "EngineRunning", self.OnEngineStateChange )
 end
 
@@ -269,9 +272,9 @@ end
 function ENT:SetChannelMode( channel, state )
 	state = state or "OFF"
 	
-	local oldState = self:GetNW2String("Photon2:CS:" .. channel, "OFF" )
+	local oldState = self:GetParent():GetNW2String("Photon2:CS:" .. channel, "OFF" )
 
-	self:SetNW2String( "Photon2:CS:" .. channel, string.upper(state) )
+	self:GetParent():SetNW2String( "Photon2:CS:" .. channel, string.upper(state) )
 
 	if CLIENT then
 		-- this line may be necessary for client prediction but it's doing some really weird shit
@@ -286,17 +289,18 @@ end
 ---@param channel string
 ---@return string
 function ENT:GetChannelMode( channel )
-    return self:GetNW2String( "Photon2:CS:" .. channel, "OFF" )
+    return self:GetParent():GetNW2String( "Photon2:CS:" .. channel, "OFF" )
 end
 
----@return string
-function ENT:GetProfileName()
-	return self:GetNW2String( "Photon2:ProfileName" )
-end
+-- -@return string
+-- function ENT:GetProfileName()
+	-- return self:GetDTProfileName()
+	-- return self:GetNW2String( "Photon2:ProfileName" )
+-- end
 
 
-function ENT:GetProfile( )
-	return Photon2.GetVehicle( self:GetProfileName() )
+function ENT:GetProfile( name )
+	return Photon2.GetVehicle( name or self:GetProfileName() )
 end
 
 ENT.UserCommands = {
@@ -922,7 +926,7 @@ end
 function ENT:SetupProfile( name, isReload )
 	name = name or self:GetProfileName()
 	---@type PhotonVehicle
-	local profile = self:GetProfile()
+	local profile = self:GetProfile( name )
 
 	if ( profile.InvalidVehicle ) then 
 		warn( "Vehicle profile [%s] uses a vehicle that does not exist [%s]. Aborting setup.", name, profile.Target )
@@ -1097,7 +1101,7 @@ end
 
 
 function ENT:GetSelectionsString()
-	return self:GetNW2String( "Photon2:Selections" )
+	return self:GetParent():GetNW2String( "Photon2:Selections" )
 end
 
 function ENT:GetActiveComponents()
@@ -1283,6 +1287,11 @@ function ENT:OnEngineStateChange( name, old, new )
 	else
 		self:SetChannelMode( "Vehicle.Engine", "OFF" )
 	end
+end
+
+function ENT:OnProfileNameChange( name, old, new )
+	print("Profile name change: " .. tostring( new ) )
+	self:SetupProfile( new )
 end
 
 function ENT:GetSirenSelection( number )

--- a/lua/photon-v2/cl_net.lua
+++ b/lua/photon-v2/cl_net.lua
@@ -32,34 +32,45 @@ net.Receive( "Photon2:SetPlayerInputControllerTarget", Photon2.cl_Network.OnSetI
 
 function Photon2.cl_Network.OnNetworkVarChanged( ent, name, oldValue, newValue )
 	if ( not IsValid( ent ) ) then return end
-	if ( ent:GetClass() == "photon_controller" ) then
+	
+	local isController = false
+	local controller = ent
+
+	if( IsValid( ent:GetPhotonController() ) ) then
+		controller = ent:GetPhotonController()
+		isController = true
+	elseif ( ent:GetClass() == "photon_controller" ) then
+		isController = true
+	end
+
+	if ( isController ) then
 		
-		if ( not ent.IsPhotonController ) then
+		if ( not controller.IsPhotonController ) then
 			-- This is to briefly keep change-notifications in a queue because 
 			-- the values sometimes change before the controller is fully
 			-- initialized on the client (no idea why).
 			local queue = Photon2.cl_Network.ControllerQueue
-			queue[ent] = queue[ent] or {
+			queue[controller] = queue[controller] or {
 				Time = CurTime(),
 				Channels = {},
 			}
 			
 			if (string.StartsWith(name,"Photon2:CS:")) then
 				name = string.sub( name, 12 )
-				queue[ent].Channels[name] = newValue
+				queue[controller].Channels[name] = newValue
 			elseif (name == "Photon2:ProfileName") then
-				queue[ent].Profile = newValue
+				queue[controller].Profile = newValue
 			elseif (name == "Photon2:Selections") then
-				queue[ent].SelectionsString = newValue
+				queue[controller].SelectionsString = newValue
 			end
 		else
 			if (string.StartsWith(name,"Photon2:CS:")) then
 				name = string.sub( name, 12 )
-				ent:OnChannelModeChanged( name, newValue, oldValue )
+				controller:OnChannelModeChanged( name, newValue, oldValue )
 			elseif (name == "Photon2:ProfileName") then
-				ent:SetupProfile( newValue )
+				controller:SetupProfile( newValue )
 			elseif (name == "Photon2:Selections") then
-				ent:ProcessSelectionsString( newValue )
+				controller:ProcessSelectionsString( newValue )
 			end
 		end
 	elseif ( ent:GetClass() == "prop_physics" ) then

--- a/lua/photon-v2/library/components/photon_fedsig_legend.lua
+++ b/lua/photon-v2/library/components/photon_fedsig_legend.lua
@@ -219,6 +219,10 @@ COMPONENT.Segments = {
 				:Sequential( 7, 4 ):Hold( 3 ):Sequential( 4, 1 ):Add( 0 ):Hold( 3 )
 				:Sequential( 1, 4 ):Hold( 3 ):Sequential( 4, 7 ):Add( 0 ):Hold( 3 )
 				:Sequential( 7, 4 ):Hold( 3 ):Sequential( 4, 1 ):Add( 0 ):Hold( 3 )
+				:Sequential( 1, 4 ):Hold( 3 ):Sequential( 4, 7 ):Add( 0 ):Hold( 3 )
+				:Sequential( 7, 4 ):Hold( 3 ):Sequential( 4, 1 ):Add( 0 ):Hold( 3 )
+				:Sequential( 1, 4 ):Hold( 3 ):Sequential( 4, 7 ):Add( 0 ):Hold( 3 )
+				:Sequential( 7, 4 ):Hold( 3 ):Sequential( 4, 1 ):Add( 0 ):Hold( 3 )
 				:Add( 8, 0, 8, 9, 0, 10, 10, 11, 12, 0, 13, 13, 14, 0, 15, 15 ):Stretch( 2 )
 		}
 	},

--- a/lua/photon-v2/sv_init.lua
+++ b/lua/photon-v2/sv_init.lua
@@ -79,6 +79,7 @@ function Photon2.AddControllerToVehicle( vehicle, profile )
 	controller:SetLocalAngles(Angle(0, 0, 0))
 
 	controller:SetProfileName( profile )
+	controller:SetupProfile( profile )
 
 	if ( vehicle:IsVehicle() ) then controller.IsLinkedToStandardVehicle = true end
 


### PR DESCRIPTION
- NW2Var networking is now done on a photon_controller's parent entity as a interim solution

- Some networked data was switched to use the controller's data-table

- Photon controllers parented to Lua-based entities are highly likely to continue having issues in multiplayer