### PR TITLE
Fix for Equipment annotations

### DIFF
--- a/.annotations/photon-v2.lua
+++ b/.annotations/photon-v2.lua
@@ -263,7 +263,7 @@ PhotonMaterial = PhotonMaterial
 ---@field Name? string Unique equipment entry name. Only required if you want other entries to inherit from it.
 ---@field Inherit? string Name of an equipment entry to inherit from.
 
----@class PhotonEquipmentComponentEntry : PhotonEquipmentEntityProperties, PhotonEquipmentLibraryComponentProperties
+---@class PhotonEquipmentComponentEntry : PhotonEquipmentEntityProperties, [PhotonEquipmentLibraryComponentProperties]
 
 ---@class PhotonEquipmentPropEntry : PhotonEquipmentEntityProperties
 ---@field Model? string Model path. (e.g. `models/my/props/model.mdl`)


### PR DESCRIPTION
fix to keep the following from happening by making the not-actually-necessary fields optional in the annotations file
![image](https://github.com/user-attachments/assets/c6474def-5197-4434-a8c0-f3d9cc864b5d)
