### PR TITLE
Add "M" state to 2D, Projected, and Mesh

### DIFF
--- a/lua/photon-v2/meta/light_2d.lua
+++ b/lua/photon-v2/meta/light_2d.lua
@@ -86,6 +86,7 @@ local redHalogen = { r = 255, g = 50, b = 70 }
 local blue = { r = 0, g = 0, b = 255 }
 local green = { r = 0, g = 255, b = 0 }
 local amber = { r = 255, g = 0, b = 0 }
+local miku = { r = 0, g = 221, b = 192 }
 
 Light.States = {
 	["~OFF"] = {
@@ -174,7 +175,14 @@ Light.States = {
 		InnerGlowColor = Color( 0, 0, 0 ),
 		ShapeGlowColor = Color( 0, 0, 0 ),
 		Intensity = 0.5
-	}
+	},
+	["M"] = {
+		SourceDetailColor = PhotonColor(0,255,100):Blend(miku):GetBlendColor(), 
+		SourceFillColor = PhotonColor(0,64,100):Blend(miku):GetBlendColor(),
+		GlowColor = PhotonColor( 0, 100, 100 ):Blend(miku):GetBlendColor(), --*
+		InnerGlowColor = PhotonColor( 0, 128, 100 ):Blend(miku):GetBlendColor(),
+		ShapeGlowColor = PhotonColor( 0, 128, 100 ):Blend(miku):GetBlendColor(),
+	},
 }
 function Light.OnLoad()
 	for k, v in pairs( Light.States ) do

--- a/lua/photon-v2/meta/light_mesh.lua
+++ b/lua/photon-v2/meta/light_mesh.lua
@@ -41,6 +41,7 @@ local blue = { r = 0, g = 0, b = 255 }
 local green = { r = 0, g = 255, b = 0 }
 local amber = { r = 255, g = 128, b = 0 }
 local black = { r = 0, g = 0, b = 0 }
+local miku = { r = 0, g = 221, b = 192 }
 
 Light.States = {
 	["~OFF"] = {
@@ -75,6 +76,10 @@ Light.States = {
 	["SW"] = {
 		BloomColor = PhotonColor( 255, 195, 175 ):Blend( softWhite ):GetBlendColor(),
 		DrawColor = PhotonColor( 255, 245, 205 ):Blend( softWhite ):GetBlendColor(),
+	},
+	["M"] = {
+		BloomColor = PhotonColor( 0, 150, 120 ):Blend( miku ):GetBlendColor(),
+		DrawColor = PhotonColor( 75, 225, 190 ):Blend( miku ):GetBlendColor(),
 	},
 }
 

--- a/lua/photon-v2/meta/light_projected.lua
+++ b/lua/photon-v2/meta/light_projected.lua
@@ -26,6 +26,8 @@ local red = { r = 255, g = 0, b = 0 }
 local blue = { r = 0, g = 0, b = 255 }
 local green = { r = 0, g = 255, b = 0 }
 local amber = { r = 255, g = 210, b = 0 }
+local miku = { r = 0, g = 221, b = 192 }
+
 
 Light.States = {
 	["~OFF"] = {
@@ -52,6 +54,9 @@ Light.States = {
 	},
 	["G"] = {
 		Color = PhotonColor( 0, 255, 0 ):Blend( green ):GetBlendColor()
+	},
+	["M"] = {
+		Color = PhotonColor( 0, 255, 222 ):Blend( miku ):GetBlendColor()
 	}
 }
 


### PR DESCRIPTION
Added the M state for Hatsune Miku Blue.

![gm_bigcity_improved0006](https://github.com/user-attachments/assets/4a4cf72e-578f-44b0-a27f-0d0b12de7e7a)
![gm_bigcity_improved0004](https://github.com/user-attachments/assets/43af3f76-1371-4949-9567-0fef4f1d1efe)
![gm_bigcity_improved0003](https://github.com/user-attachments/assets/18e7b544-9979-4aeb-9eb6-40ee304d4e50)
