### PR TITLE
Fix lua error and micro-optimization

### DIFF
--- a/lua/photon-v2/meta/vehicle.lua
+++ b/lua/photon-v2/meta/vehicle.lua
@@ -277,7 +277,7 @@ function Vehicle.New( data )
 	local target = list.GetForEdit( "Vehicles" )[data.Vehicle]
 	if ( not target ) then
 		target = scripted_ents.GetList()[data.Vehicle].t --glide compat (and possibly other entity based vehicles, havent tested)
-		if target.GlideCategory then
+		if target and target.GlideCategory then
 			glideVehicle = true
 		end
 		if ( not target ) then

--- a/lua/photon-v2/meta/vehicle.lua
+++ b/lua/photon-v2/meta/vehicle.lua
@@ -276,15 +276,17 @@ function Vehicle.New( data )
 	---@type VehicleTable
 	local target = list.GetForEdit( "Vehicles" )[data.Vehicle]
 	if ( not target ) then
-		target = scripted_ents.GetList()[data.Vehicle].t --glide compat (and possibly other entity based vehicles, havent tested)
-		if target and target.GlideCategory then
-			glideVehicle = true
-		end
-		if ( not target ) then
+		target = scripted_ents.GetList()[data.Vehicle] --glide compat (and possibly other entity based vehicles, havent tested)
+		if ( not target or not istable(target.t) ) then
 			warn("Vehicle target [" .. tostring(data.Vehicle) .. "] does not appear to exist. Ensure the name is correct and you have the required addons.")
 			target = Vehicle.GetError()
 			invalidVehicle = true
 			title = "[ERROR] " .. title
+		end
+		
+		target = target.t
+		if target and target.GlideCategory then
+			glideVehicle = true
 		end
 	end
 

--- a/lua/photon-v2/sv_init.lua
+++ b/lua/photon-v2/sv_init.lua
@@ -101,14 +101,11 @@ function Photon2.AddControllerToVehicle( vehicle, profile )
 	controller:SetupProfile( profile )
 
 	-- if ( vehicle:IsVehicle() ) then controller.IsLinkedToStandardVehicle = true end
-	--hacky glide compat
 	if ( string.find(vehicle:GetClass(), "prop_vehicle_") ) then
 		controller.IsLinkedToStandardVehicle = true
-	else
-		if ( string.find(vehicle.Base, "glide") ) then
-			controller.IsLinkedToGlideVehicle = true
-			controller:SetLinkedToGlideVehicle( true )
-		end
+	elseif vehicle.IsGlideVehicle then
+		controller.IsLinkedToGlideVehicle = true
+		controller:SetLinkedToGlideVehicle( true )
 	end
 
 	vehicle:SetPhotonController( controller )


### PR DESCRIPTION
Hello,
This PR aims to use the Glide variable that determines whether an item is a vehicle or not.

It also allows for a Lua error if `scripted_ents.GetList` returns `nil`.